### PR TITLE
Add option.winVersionString for accurate process name (always nwjs previously)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,24 @@ Default value: `false`
 
 MAC ONLY: Pass a string containing the path to your own plist file. If a string isn't passed, a plist file will be generated from your package.json. Pass an object to overwrite or add properties to the generated plist file.
 
+
+#### options.winVersionString
+Type: `Object`
+Default value: `{}`
+
+WINDOWS ONLY: Some descriptors of the executable. If your don't provide your own `FileDescription`, it will default to `options.appName`. If you are building on MAC or LINUX you must have [Wine](https://www.winehq.org/) installed to use this option.
+
+See [the MSDN docs](https://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#string-name) for more options than the basic list below,
+
+```
+winVersionString: {
+  'CompanyName': 'Some Company',
+  'FileDescription': 'Process Name',
+  'ProductName': 'Some Product',
+  'LegalCopyright': 'Copyright 2017',
+}
+```
+
 #### options.winIco
 Type: `String`  
 Default value: `null`
@@ -304,5 +322,3 @@ See [CHANGELOG.md](CHANGELOG.md) or [Releases](https://github.com/nwjs-community
 
 [depstat-url]: https://david-dm.org/nwjs/nw-builder
 [depstat-image]: https://david-dm.org/nwjs/nw-builder.svg?style=flat
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var recursiveReaddirSync = require('recursive-readdir-sync');
 var path = require('path');
 var url = require('url');
 var thenify = require('thenify');
+var rcedit = thenify(require('rcedit'));
 var winresourcer = thenify(require('winresourcer'));
 var spawn = require('child_process').spawn;
 var semver = require('semver');
@@ -70,6 +71,7 @@ function NwBuilder(options) {
         zip: null,
         zipOptions: null,
         macPlist: false,
+        winVersionString: {},
         winIco: null,
         argv: process.argv.slice(2)
     };
@@ -670,30 +672,43 @@ NwBuilder.prototype.handleWinApp = function () {
     this._forEachPlatform(function (name, platform) {
         if(!self.options.winIco || ['win32', 'win64'].indexOf(name) < 0) return;
 
-        // build a promise chain
-        allDone.push(new Promise(function(resolve, reject) {
-            self.emit('log', 'Update ' + name + ' executable icon');
-            var executableName = self._version.isLegacy ? _.first(platform.files) : self.getExecutableName(name);
-            // Set icon
-            winresourcer({
-                operation: "Update",
-                exeFile: path.resolve(platform.releasePath, executableName),
-                resourceType: "Icongroup",
-                resourceName: "IDR_MAINFRAME",
-                lang: 1033, // Required, except when updating or deleting
-                resourceFile: path.resolve(self.options.winIco)
-            }, function(err) {
-                if(!err) { resolve(); }
-                else {
-                    reject('Error while updating the Windows icon.' +
-                        (process.platform !== "win32"
-                                ? ' Wine (winehq.org) must be installed to add custom icons from Mac and Linux.'
-                                : ''
-                        )
-                    );
-                }
+        var executableName = self._version.isLegacy ? _.first(platform.files) : self.getExecutableName(name);
+        var executablePath =  path.resolve(platform.releasePath, executableName);
+
+        var updateVersionStringPromise = rcedit(executablePath, {
+            'version-string': Object.assign({}, {
+                // The process name used in the Task Manager
+                FileDescription: self.options.appName,
+            }, self.options.winVersionString)
+        });
+
+        var updateIconsPromise = updateVersionStringPromise.then(function() {
+            return new Promise(function(resolve, reject) {
+                self.emit('log', 'Update ' + name + ' executable icon');
+                // Set icon
+                winresourcer({
+                    operation: "Update",
+                    exeFile: executablePath,
+                    resourceType: "Icongroup",
+                    resourceName: "IDR_MAINFRAME",
+                    lang: 1033, // Required, except when updating or deleting
+                    resourceFile: path.resolve(self.options.winIco)
+                }, function(err) {
+                    if(!err) { resolve(); }
+                    else {
+                        reject('Error while updating the Windows icon.' +
+                            (process.platform !== "win32"
+                                    ? ' Wine (winehq.org) must be installed to add custom icons from Mac and Linux.'
+                                    : ''
+                            )
+                        );
+                    }
+                });
             });
-        }));
+        });
+
+        // build a promise chain
+        allDone.push(updateIconsPromise);
     });
 
     return Promise.all(allDone);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "platform-overrides": "~1.0.1",
     "plist": "^2.0.1",
     "progress": "~1.1.7",
+    "rcedit": "^0.9.0",
     "recursive-readdir-sync": "^1.0.6",
     "request": "~2.81.0",
     "rimraf": "^2.5.2",


### PR DESCRIPTION
Fixes https://github.com/nwjs-community/nw-builder/issues/196
Fixes https://github.com/nwjs-community/nw-builder/issues/315

Add `option.winVersionString` for accurate process name

The main goal was to fix the issue where the process showed up as `nwjs` in the Windows 10 Task Manager (now defaults to the `options.appName`). When trying to change `FileDescription` via [`rcedit`](https://www.npmjs.com/package/rcedit) as a post-process to the `nw-builder` build, I would always get a blank/default-shimmer NW.js page when starting up the app instead of the specified `main` file.

Allows you to edit the version string of the resultant Windows executable. These can be easily viewed in Properties -> Details,

```
winVersionString: {
  'CompanyName': 'Some Company',
  'FileDescription': 'Process Name',
  'ProductName': 'Some Product',
  'LegalCopyright': 'Copyright 2017',
}
```

Before | After
--- | ---
![](http://i.imgur.com/oqyRwaa.png) | ![](http://i.imgur.com/YLvegHw.png)


---

Instead of just `version-string`, we could generalize this more to allow more of the [`rcedit` options](https://github.com/electron/node-rcedit#rceditexepath-options-callback) like `file-version`, perhaps as `options.winRc`.

`version-string` covers these properties, https://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#string-name

---

Also see

 - https://github.com/nwjs/nw.js/issues/5809
 - https://github.com/nwjs/nw.js/issues/5807
 - https://github.com/nwjs/nw.js/issues/4293
 - https://github.com/nwjs/nw.js/issues/2160
 - https://github.com/nwjs/nw.js/issues/5829
