### PR TITLE
Apply option.winVersionString even if there is no option.winIco

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -674,7 +674,7 @@ NwBuilder.prototype.handleWinApp = function () {
         allDone = [];
 
     this._forEachPlatform(function (name, platform) {
-        if(!self.options.winIco || ['win32', 'win64'].indexOf(name) < 0) return;
+        if(['win32', 'win64'].indexOf(name) < 0) return;
 
         var executableName = self._version.isLegacy ? _.first(platform.files) : self.getExecutableName(name);
         var executablePath =  path.resolve(platform.releasePath, executableName);
@@ -685,6 +685,10 @@ NwBuilder.prototype.handleWinApp = function () {
                 FileDescription: self.options.appName,
             }, self.options.winVersionString)
         });
+
+        if (!self.options.winIco) {
+            return updateVersionStringPromise;
+        }
 
         var updateIconsPromise = updateVersionStringPromise.then(function() {
             return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Thanks for the amazing nw-builder. Found a small problem when using it, if missing option.WinIco, option.winVersionString will not work. I think it should be independent of each other. This is the really first time I make a contribution, so please let me know if I did any thing wrong. Thanks again!