### PR TITLE
Add optional compile using nwjc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ function NwBuilder(options) {
         macPlist: false,
         winVersionString: {},
         winIco: null,
+        compileFiles: [],
         argv: process.argv.slice(2)
     };
     // Intercept the platforms and check for the legacy platforms of 'osx' and 'win' and
@@ -287,34 +288,47 @@ NwBuilder.prototype.downloadNwjs = function () {
         downloads = [];
 
     this._forEachPlatform(function (name, platform) {
-        self.setPlatformCacheDirectory(name, platform, self._version.version, self._version.flavor);
-        platform.url = self._version.platforms[name + '-' + self._version.flavor];
 
-        // Ensure that there is a cache folder
-        if(self.options.forceDownload) {
-            fs.removeSync(platform.cache);
-        }
+        _.forEach(['normal','sdk'], function(flavor) {
 
-        fs.mkdirpSync(platform.cache);
-        self.emit('log', 'Create cache folder in ' + path.resolve(self.options.cacheDir, self._version.version + '-' + self._version.flavor));
+            if (flavor == self._version.flavor || (flavor == 'sdk' && self.options.compileFiles.length > 0)) {
 
-        if(!self.isPlatformCached(name, platform, self._version.version, self._version.flavor)) {
-            downloads.push(
-                Downloader.downloadAndUnpack(platform.cache, platform.url)
-                    .catch(function(err){
-                        if(err.statusCode === 404){
-                            self.emit('log', 'ERROR: The version '+self._version.version+ ' (' + self._version.flavor + ') does not have a corresponding build posted at ' + self.options.downloadUrl + '. Please choose a version from that list.');
-                        } else {
-                            self.emit('log', err.msg);
-                        }
+                if (flavor == self._version.flavor) {
+                    self.setPlatformCacheDirectory(name, platform, self._version.version, flavor);
+                    platform.url = self._version.platforms[name + '-' + flavor];
+                }
 
-                        return Promise.reject('Unable to download NWjs.');
-                    })
-            );
-            self.emit('log', 'Downloading: ' + platform.url);
-        } else {
-            self.emit('log', 'Using cache for: ' + name);
-        }
+                if (flavor == 'sdk') {
+                  platform.sdkcache = path.resolve(self.options.cacheDir, self._version.version + "-" + flavor, name)
+                }
+
+                // Ensure that there is a cache folder
+                if(self.options.forceDownload) {
+                    fs.removeSync(platform.cache);
+                }
+
+                fs.mkdirpSync(platform.cache);
+                self.emit('log', 'Create cache folder in ' + path.resolve(self.options.cacheDir, self._version.version + '-' + flavor));
+
+                if(!self.isPlatformCached(name, platform, self._version.version, flavor)) {
+                    downloads.push(
+                        Downloader.downloadAndUnpack(platform.cache, platform.url)
+                            .catch(function(err){
+                                if(err.statusCode === 404){
+                                    self.emit('log', 'ERROR: The version '+self._version.version+ ' (' + flavor + ') does not have a corresponding build posted at ' + self.options.downloadUrl + '. Please choose a version from that list.');
+                                } else {
+                                    self.emit('log', err.msg);
+                                }
+
+                                return Promise.reject('Unable to download NWjs.');
+                            })
+                    );
+                    self.emit('log', 'Downloading: ' + platform.url);
+                } else {
+                    self.emit('log', 'Using cache for: ' + name);
+                }
+            }
+        });
     });
 
     return Promise.all(downloads)
@@ -493,7 +507,6 @@ NwBuilder.prototype.zipAppFiles = function () {
     // Check if zip is needed
     var doAnyNeedZip = false,
         _needsZip = false,
-        zipOptions = this.options.zipOptions;
         numberOfPlatformsWithoutOverrides = 0;
 
     self._zips = {};
@@ -502,7 +515,7 @@ NwBuilder.prototype.zipAppFiles = function () {
         var needsZip = self.isPlatformNeedingZip(name, platform);
 
         if(needsZip) {
-            var platformSpecific = !!platform.platformSpecificManifest;
+            var platformSpecific = !!platform.platformSpecificManifest || self.options.compileFiles.length > 0
 
             self._zips[name] = { platformSpecific: platformSpecific };
 
@@ -525,7 +538,7 @@ NwBuilder.prototype.zipAppFiles = function () {
         // create (or don't create) a ZIP for multiple platforms
         new Promise(function(resolve, reject) {
             if(numberOfPlatformsWithoutOverrides > 1){
-                Utils.generateZipFile(self._files, self, null, zipOptions).then(function (zip) {
+                Utils.generateZipFile(self._files, self, self.options, null, null).then(function (zip) {
                     resolve(zip);
                 }, reject);
             }
@@ -546,8 +559,9 @@ NwBuilder.prototype.zipAppFiles = function () {
                     zipPromises.push(Utils.generateZipFile(
                         self._files,
                         self,
-                        JSON.stringify(self._platforms[platformName].platformSpecificManifest),
-                        zipOptions
+                        self.options,
+                        self._platforms[platformName],
+                        platformName
                     ).then(function(file){
                         zip.file = file;
                     }));

--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -4,6 +4,7 @@ module.exports = {
     win32: {
         needsZip: true,
         getRunnable: function() { return 'nw.exe'; },
+        getCompiler: function() { return 'nwjc.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'],
             '>0.9.2 <0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
@@ -14,6 +15,7 @@ module.exports = {
     win64: {
         needsZip: true,
         getRunnable: function() { return 'nw.exe'; },
+        getCompiler: function() { return 'nwjc.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
             '>0.9.2 <0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
@@ -30,6 +32,7 @@ module.exports = {
                 return 'node-webkit.app/Contents/MacOS/node-webkit';
             }
         },
+        getCompiler: function() { return 'nwjs.app/Contents/MacOS/nwjc' },
         files: {
             '<0.12.0-alpha': ['node-webkit.app'],
             '>=0.12.0 || ~0.12.0-alpha': ['nwjs.app']
@@ -45,6 +48,7 @@ module.exports = {
                 return 'node-webkit.app/Contents/MacOS/node-webkit';
             }
         },
+        getCompiler: function() { return 'nwjs.app/Contents/MacOS/nwjc' },
         files: {
             '<0.12.0-alpha': ['node-webkit.app'],
             '>=0.12.0 || ~0.12.0-alpha': ['nwjs.app']
@@ -55,6 +59,7 @@ module.exports = {
         needsZip: true,
         chmod: '0755',
         getRunnable: function() { return 'nw'; },
+        getCompiler: function() { return 'nwjc'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so'],
             '>0.9.2 <=0.10.1': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat'],
@@ -66,6 +71,7 @@ module.exports = {
         needsZip: true,
         chmod: '0755', // chmod file file to be executable
         getRunnable: function() { return 'nw'; },
+        getCompiler: function() { return 'nwjc'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so'],
             '>0.9.2 <=0.10.1': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat'],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,8 @@ var Glob = require('simple-glob');
 var temp = require('temp');
 var archiver = require('archiver');
 var thenify = require('thenify');
+var spawn = require('child_process').spawn;
+
 
 var readFile = thenify(fs.readFile);
 var writeFile = thenify(fs.writeFile);
@@ -133,9 +135,14 @@ module.exports = {
             zipStream.pipe(writeStream);
         });
     },
-    generateZipFile: function (files, _event, platformSpecificManifest, zipOptions) {
+    generateZipFile: function (files, _event, options, platform, platformName) {
         var destStream = temp.createWriteStream(),
-            archive = archiver('zip', zipOptions || {});
+            archive = archiver('zip', options.zipOptions || {});
+
+        var compileFilesExpanded = []
+        _.forEach(options.compileFiles, function(glob){
+          compileFilesExpanded = compileFilesExpanded.concat(Glob(glob))
+        });
 
         return new Promise(function(resolve, reject) {
 
@@ -149,13 +156,40 @@ module.exports = {
 
             // Add the files
             var filesBulk = [];
+            var compilePromises = []
             files.forEach(function(file){
-                if(file.dest === 'package.json' && platformSpecificManifest){
-                    archive.append(platformSpecificManifest, {name: 'package.json'});
+                if(file.dest === 'package.json' && platform && platform.platformSpecificManifest){
+                    archive.append(platform.platformSpecificManifest, {name: 'package.json'});
+                }
+                else if(compileFilesExpanded.includes(file.src)) {
+                    var cmd = path.join(platform.sdkcache, platform.getCompiler())
+                    var tempName = temp.path();
+                    var args = [file.src, tempName]
+
+                    if ( process.platform == 'linux' && ( platformName == 'win32' || platformName == 'win64' ) ) {
+                      args.unshift(cmd)
+                      cmd = 'wine'
+                    }
+
+                    compilePromises.push(new Promise(function(resolve, reject) {
+
+                        var nwjc = spawn(cmd , args, { stdio: 'inherit' })
+                        nwjc.on('close', function(code, signal) {
+                            if(code !== 0) {
+                                reject('nwjc failed')
+                            }
+                            else {
+                                archive.append("nw.Window.get().evalNWBin(null,'" + file.dest + ".bin');", {name: file.dest})
+                                archive.file(tempName, {name: file.dest + '.bin'});
+                                resolve()
+                            }
+                        })
+                    }))
+
                 }
                 else
                 {
-					archive.file(file.src, {name: file.dest});
+					          archive.file(file.src, {name: file.dest});
                 }
             });
 
@@ -164,9 +198,12 @@ module.exports = {
                 _event.emit('log', 'Zipping ' + file.name);
             });
 
-            // Pipe the stream
-            archive.pipe(destStream);
-            archive.finalize();
+            // Wait for compile(s) to finish
+            Promise.all(compilePromises).then(function(){
+                // Pipe the stream
+                archive.pipe(destStream);
+                archive.finalize();
+            });
 
         });
     },


### PR DESCRIPTION
These changes add a new configuration parameter "compileFiles" which is a array of globs. Any matching files will be compiled using nwjc during ZIP packing. To be able to do so the sdk is also downloaded (but used only for nwjc) when this option is set, even if the target flavor is 'normal'.

Usage example:

```
  var nw = new NwBuilder({
    files: './dist/**/**',
    platforms: [ 'linux64', 'win64' ],
    version: '0.31.5',
    buildDir: './releases',
    cacheDir: './cache',
    compileFiles: [ 'dist/**/main.js' ],
    flavor: 'normal'
  })

```