### PR TITLE
chore: support custom nwjs download url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ function NwBuilder(options) {
         version: 'latest',
         buildDir: './build',
         cacheDir: './cache',
-        downloadUrl: 'https://dl.nwjs.io/',
+        downloadUrl: process.env.npm_config_nwjs_builder_urlbase || process.env.NWJS_BUILDER_URLBASE || 'https://dl.nwjs.io/',
         manifestUrl: 'https://nwjs.io/versions.json',
         flavor: 'sdk',
         buildType: 'default',


### PR DESCRIPTION
connect is unstable from some region, and there are lots of mirrors that we can use. we can offer a custom way for users.