### PR TITLE
Add option to remove quarantine for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file and in the [
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.6.1]
+
+### Added
+
+- Option to remove Quarantine for macOS.
+
 ## [3.5.7]
 
 ### Security

--- a/bin/nwbuild
+++ b/bin/nwbuild
@@ -38,6 +38,11 @@ var argv = optimist
     .describe('quiet', 'Disables logging')
     .boolean('quiet')
 
+    .alias('q', 'quarantine')
+    .describe('q', 'Remove quarantine from Info.plist. Applicable for macOS only')
+    .default('q', false)
+    .boolean('q')
+
     .argv;
 
 // Howto Help
@@ -63,7 +68,8 @@ var options = {
     winIco: argv.winIco || false,
     cacheDir: argv.cacheDir ? path.resolve(process.cwd(), argv.cacheDir) : path.resolve(__dirname, '..', 'cache'),
     buildDir: path.resolve(process.cwd(), argv.buildDir),
-    forceDownload: argv.forceDownload
+    forceDownload: argv.forceDownload,
+    removeQuarantine: argv.quarantine
 };
 
 // If we are in run mode

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ function NwBuilder(options) {
         macPlist: false,
         winVersionString: {},
         winIco: null,
+        removeQuarantine: false,
         argv: process.argv.slice(2)
     };
     // Intercept the platforms and check for the legacy platforms of 'osx' and 'win' and
@@ -663,7 +664,13 @@ NwBuilder.prototype.handleMacApp = function () {
             );
 
             allDone.push(Utils.editPlist(PlistPath, PlistPath, plistOptions));
+
+            // remove Quarantine
+            if (self.options.removeQuarantine) {
+                allDone.push(Utils.removeQuarantineFromPlist(PlistPath, PlistPath));
+            }
         }
+
     });
 
     return Promise.all(allDone);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -245,5 +245,23 @@ module.exports = {
                 // Write output file
                 return writeFile(plistOutput, plist.build(info));
             });
+    },
+    removeQuarantineFromPlist: function(plistInput, plistOutput) {
+
+        // Read the input file
+        return readFile(plistInput, 'utf8')
+            // Parse it
+            .then(plist.parse)
+            // Then overwrite the properties with custom values
+            .then(function(info) {
+
+                // Delete LSFileQuarantineEnabled
+                if(info.hasOwnProperty('LSFileQuarantineEnabled')) {
+                    delete info.LSFileQuarantineEnabled
+                }
+
+                // Write output file
+                return writeFile(plistOutput, plist.build(info));
+            });
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-builder",
-  "version": "3.5.7",
+  "version": "3.6.1",
   "description": "nw-builder",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Co-Authored-By: Jairo Leon <33960025+jaileon@users.noreply.github.com>

When writing internal applications it is sometimes needed to remove the `LSFileQuarantineEnabled` property from Info.plist

This PR addresses the problem by adding a switch to enable this. 